### PR TITLE
feat: Finish learning session

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -217,6 +217,10 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
+dotnet_naming_rule.private_fields_start_with_underscore.severity = suggestion
+dotnet_naming_rule.private_fields_start_with_underscore.symbols = private_fields
+dotnet_naming_rule.private_fields_start_with_underscore.style = private_field_underscore_style
+
 # Symbol specifications
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
@@ -231,6 +235,9 @@ dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, meth
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.non_field_members.required_modifiers = 
 
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
 # Naming styles
 
 dotnet_naming_style.pascal_case.required_prefix = 
@@ -242,6 +249,11 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.private_field_underscore_style.capitalization = camel_case
+dotnet_naming_style.private_field_underscore_style.required_prefix = _
+dotnet_naming_style.private_field_underscore_style.word_separator = 
+
 
 [*.{cs,vb}]
 dotnet_style_operator_placement_when_wrapping = beginning_of_line

--- a/src/StickedWords.API/Endpoints/LearningSessionEndpoints.cs
+++ b/src/StickedWords.API/Endpoints/LearningSessionEndpoints.cs
@@ -11,24 +11,49 @@ public static class LearningSessionEndpoints
     {
         var group = builder.MapGroup("/api/learning-sessions");
 
-        group.MapGet("/", GetLearningSession);
-        group.MapPost("/", AddLearningSession);
+        group.MapGet("/{id}", GetLearningSessionById);
+        group.MapGet("/", GetActiveLearningSession);
+        group.MapGet("/{id}/results", GetLearningSessionResults);
+        group.MapPost("/", CreateLearningSession);
 
         return builder;
     }
 
-    private static async Task<LearningSessionDto?> GetLearningSession(
+    private static async Task<LearningSessionDto?> GetActiveLearningSession(
         IMediator mediator,
         CancellationToken cancellationToken)
     {
-        var request = new GetLearningSessionQuery();
+        var request = new GetActiveLearningSessionQuery();
         var session = await mediator.Send(request, cancellationToken);
         var result = session?.ToDto();
 
         return result;
     }
 
-    private static async Task<LearningSessionDto> AddLearningSession(
+    private static async Task<LearningSessionDto?> GetLearningSessionById(
+        long id,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var request = new GetLearningSessionByIdQuery(id);
+        var session = await mediator.Send(request, cancellationToken);
+        var result = session?.ToDto();
+
+        return result;
+    }
+
+    private static async Task<LearningSessionResultsDto> GetLearningSessionResults(
+        long id,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var request = new GetLearningSessionResultsQuery(id);
+        var result = await mediator.Send(request, cancellationToken);
+
+        return result.ToDto();
+    }
+
+    private static async Task<LearningSessionDto> CreateLearningSession(
         IMediator mediator,
         CancellationToken cancellationToken)
     {

--- a/src/StickedWords.API/Mappers/LearningSessionMapper.cs
+++ b/src/StickedWords.API/Mappers/LearningSessionMapper.cs
@@ -12,6 +12,8 @@ internal static class LearningSessionMapper
 
         return new()
         {
+            Id = source.Id,
+            State = source.State,
             ExerciseType = activeStage?.ExerciseType ?? ExerciseType.None,
             FlashCardId = activeStage?.CurrentFlashCard?.FlashCardId,
             FlashCardCount = source.FlashCards.Count
@@ -23,4 +25,13 @@ internal static class LearningSessionMapper
         {
             Word = source.Word
         };
+
+    public static LearningSessionResultsDto ToDto(this LearningSessionResults source)
+    {
+        return new()
+        {
+            State = source.State,
+            FlashCardCount = source.FlashCardCount
+        };
+    }
 }

--- a/src/StickedWords.API/Models/LearningSessionResultsDto.cs
+++ b/src/StickedWords.API/Models/LearningSessionResultsDto.cs
@@ -2,15 +2,9 @@
 
 namespace StickedWords.API.Models;
 
-public record LearningSessionDto
+public record LearningSessionResultsDto
 {
-    public long Id { get; init; }
-
     public LearningSessionState State { get; init; }
-
-    public ExerciseType ExerciseType { get; init; }
-
-    public long? FlashCardId { get; init; }
 
     public int FlashCardCount { get; init; }
 }

--- a/src/StickedWords.Application/Commands/LearningSessions/StartLearningSessionCommandHandler.cs
+++ b/src/StickedWords.Application/Commands/LearningSessions/StartLearningSessionCommandHandler.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using StickedWords.Domain;
 using StickedWords.Domain.Exceptions;
 using StickedWords.Domain.Models;
+using StickedWords.Domain.Models.Paging;
 using StickedWords.Domain.Repositories;
 
 namespace StickedWords.Application.Commands.LearningSessions;
@@ -35,7 +36,8 @@ internal sealed class StartLearningSessionCommandHandler : IRequestHandler<Start
         }
 
         // TODO: more intellectual method to select words
-        var flashCards = await _flashCardRepository.GetByQuery(new() { Take = _options.FlashCardCount }, cancellationToken);
+        var pageQuery = new PageQuery { Take = _options.FlashCardCount };
+        var flashCards = await _flashCardRepository.GetByQuery(pageQuery, cancellationToken);
         var learningSession = LearningSession.Create(flashCards.Data);
         learningSession.Start(_options.ExpireAfter);
         _sessionRepository.Add(learningSession);

--- a/src/StickedWords.Application/Queries/LearningSessions/GetActiveLearningSessionQuery.cs
+++ b/src/StickedWords.Application/Queries/LearningSessions/GetActiveLearningSessionQuery.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+using StickedWords.Domain.Models;
+
+namespace StickedWords.Application.Commands.LearningSessions;
+
+public record GetActiveLearningSessionQuery : IRequest<LearningSession?>;

--- a/src/StickedWords.Application/Queries/LearningSessions/GetActiveLearningSessionQueryHandler.cs
+++ b/src/StickedWords.Application/Queries/LearningSessions/GetActiveLearningSessionQueryHandler.cs
@@ -4,16 +4,16 @@ using StickedWords.Domain.Repositories;
 
 namespace StickedWords.Application.Commands.LearningSessions;
 
-internal sealed class GetLearningSessionQueryHandler : IRequestHandler<GetLearningSessionQuery, LearningSession?>
+internal sealed class GetActiveLearningSessionQueryHandler : IRequestHandler<GetActiveLearningSessionQuery, LearningSession?>
 {
     private readonly ILearningSessionRepository _sessionRepository;
 
-    public GetLearningSessionQueryHandler(ILearningSessionRepository sessionRepository)
+    public GetActiveLearningSessionQueryHandler(ILearningSessionRepository sessionRepository)
     {
         _sessionRepository = sessionRepository;
     }
 
-    public async Task<LearningSession?> Handle(GetLearningSessionQuery query, CancellationToken cancellationToken)
+    public async Task<LearningSession?> Handle(GetActiveLearningSessionQuery query, CancellationToken cancellationToken)
     {
         return await _sessionRepository.GetActive(cancellationToken);
     }

--- a/src/StickedWords.Application/Queries/LearningSessions/GetLearningSessionByIdQuery.cs
+++ b/src/StickedWords.Application/Queries/LearningSessions/GetLearningSessionByIdQuery.cs
@@ -3,4 +3,4 @@ using StickedWords.Domain.Models;
 
 namespace StickedWords.Application.Commands.LearningSessions;
 
-public record GetLearningSessionQuery : IRequest<LearningSession?>;
+public record GetLearningSessionByIdQuery(long LearningSessionId) : IRequest<LearningSession?>;

--- a/src/StickedWords.Application/Queries/LearningSessions/GetLearningSessionByIdQueryHandler.cs
+++ b/src/StickedWords.Application/Queries/LearningSessions/GetLearningSessionByIdQueryHandler.cs
@@ -1,0 +1,20 @@
+﻿using MediatR;
+using StickedWords.Domain.Models;
+using StickedWords.Domain.Repositories;
+
+namespace StickedWords.Application.Commands.LearningSessions;
+
+internal sealed class GetLearningSessionByIdQueryHandler : IRequestHandler<GetLearningSessionByIdQuery, LearningSession?>
+{
+    private readonly ILearningSessionRepository _sessionRepository;
+
+    public GetLearningSessionByIdQueryHandler(ILearningSessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository;
+    }
+
+    public async Task<LearningSession?> Handle(GetLearningSessionByIdQuery query, CancellationToken cancellationToken)
+    {
+        return await _sessionRepository.GetById(query.LearningSessionId, cancellationToken);
+    }
+}

--- a/src/StickedWords.Application/Queries/LearningSessions/GetLearningSessionResultsQuery.cs
+++ b/src/StickedWords.Application/Queries/LearningSessions/GetLearningSessionResultsQuery.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+using StickedWords.Domain.Models;
+
+namespace StickedWords.Application.Commands.LearningSessions;
+
+public record GetLearningSessionResultsQuery(long LearningSessionId) : IRequest<LearningSessionResults>;

--- a/src/StickedWords.Application/Queries/LearningSessions/GetLearningSessionResultsQueryHandler.cs
+++ b/src/StickedWords.Application/Queries/LearningSessions/GetLearningSessionResultsQueryHandler.cs
@@ -1,0 +1,31 @@
+﻿using MediatR;
+using StickedWords.Domain.Exceptions;
+using StickedWords.Domain.Models;
+using StickedWords.Domain.Repositories;
+
+namespace StickedWords.Application.Commands.LearningSessions;
+
+internal sealed class GetLearningSessionResultsQueryHandler : IRequestHandler<GetLearningSessionResultsQuery, LearningSessionResults>
+{
+    private readonly ILearningSessionRepository _sessionRepository;
+
+    public GetLearningSessionResultsQueryHandler(ILearningSessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository;
+    }
+
+    public async Task<LearningSessionResults> Handle(GetLearningSessionResultsQuery query, CancellationToken cancellationToken)
+    {
+        var session = await _sessionRepository.GetById(query.LearningSessionId, cancellationToken);
+        if (session is null)
+        {
+            throw new LearningSessionNotFoundException(query.LearningSessionId);
+        }
+
+        return new()
+        {
+            State = session.State,
+            FlashCardCount = session.FlashCards.Count
+        };
+    }
+}

--- a/src/StickedWords.DbMigrations.Postgres/Migrations/20250918191319_AddRepeatAtToFlashCard.Designer.cs
+++ b/src/StickedWords.DbMigrations.Postgres/Migrations/20250918191319_AddRepeatAtToFlashCard.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using StickedWords.Infrastructure;
@@ -11,9 +12,11 @@ using StickedWords.Infrastructure;
 namespace StickedWords.DbMigrations.Postgres.Migrations
 {
     [DbContext(typeof(StickedWordsDbContext))]
-    partial class StickedWordsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250918191319_AddRepeatAtToFlashCard")]
+    partial class AddRepeatAtToFlashCard
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/StickedWords.DbMigrations.Postgres/Migrations/20250918191319_AddRepeatAtToFlashCard.cs
+++ b/src/StickedWords.DbMigrations.Postgres/Migrations/20250918191319_AddRepeatAtToFlashCard.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace StickedWords.DbMigrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRepeatAtToFlashCard : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "RepeatAt",
+                table: "FlashCards",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<long>(
+                name: "RepeatAtUnixTime",
+                table: "FlashCards",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RepeatAt",
+                table: "FlashCards");
+
+            migrationBuilder.DropColumn(
+                name: "RepeatAtUnixTime",
+                table: "FlashCards");
+        }
+    }
+}

--- a/src/StickedWords.DbMigrations.Sqlite/Migrations/20250918191344_AddRepeatAtToFlashCard.Designer.cs
+++ b/src/StickedWords.DbMigrations.Sqlite/Migrations/20250918191344_AddRepeatAtToFlashCard.Designer.cs
@@ -2,53 +2,49 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using StickedWords.Infrastructure;
 
 #nullable disable
 
-namespace StickedWords.DbMigrations.Postgres.Migrations
+namespace StickedWords.DbMigrations.Migrations.Sqlite
 {
     [DbContext(typeof(StickedWordsDbContext))]
-    partial class StickedWordsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250918191344_AddRepeatAtToFlashCard")]
+    partial class AddRepeatAtToFlashCard
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.3")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "9.0.3");
 
             modelBuilder.Entity("StickedWords.Domain.Models.FlashCard", b =>
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Rate")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTimeOffset>("RepeatAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("RepeatAtUnixTime")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Translation")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Word")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -59,18 +55,16 @@ namespace StickedWords.DbMigrations.Postgres.Migrations
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("FlashCardId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Result")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("SessionStageId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -85,18 +79,16 @@ namespace StickedWords.DbMigrations.Postgres.Migrations
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTimeOffset>("ExpiringAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTimeOffset>("StartedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("State")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -107,15 +99,13 @@ namespace StickedWords.DbMigrations.Postgres.Migrations
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("FlashCardId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("LearningSessionId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -130,24 +120,22 @@ namespace StickedWords.DbMigrations.Postgres.Migrations
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<long?>("CurrentFlashCardId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ExerciseType")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("LearningSessionId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("OrdNumber")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 

--- a/src/StickedWords.DbMigrations.Sqlite/Migrations/20250918191344_AddRepeatAtToFlashCard.cs
+++ b/src/StickedWords.DbMigrations.Sqlite/Migrations/20250918191344_AddRepeatAtToFlashCard.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace StickedWords.DbMigrations.Migrations.Sqlite
+{
+    /// <inheritdoc />
+    public partial class AddRepeatAtToFlashCard : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "RepeatAt",
+                table: "FlashCards",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<long>(
+                name: "RepeatAtUnixTime",
+                table: "FlashCards",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RepeatAt",
+                table: "FlashCards");
+
+            migrationBuilder.DropColumn(
+                name: "RepeatAtUnixTime",
+                table: "FlashCards");
+        }
+    }
+}

--- a/src/StickedWords.DbMigrations.Sqlite/Migrations/StickedWordsDbContextModelSnapshot.cs
+++ b/src/StickedWords.DbMigrations.Sqlite/Migrations/StickedWordsDbContextModelSnapshot.cs
@@ -29,6 +29,12 @@ namespace StickedWords.DbMigrations.Migrations.Sqlite
                     b.Property<int>("Rate")
                         .HasColumnType("INTEGER");
 
+                    b.Property<DateTimeOffset>("RepeatAt")
+                        .HasColumnType("TEXT");
+
+                    b.Property<long>("RepeatAtUnixTime")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("Translation")
                         .IsRequired()
                         .HasColumnType("TEXT");
@@ -146,7 +152,7 @@ namespace StickedWords.DbMigrations.Migrations.Sqlite
                         .IsRequired();
 
                     b.HasOne("StickedWords.Domain.Models.SessionStage", "SessionStage")
-                        .WithMany()
+                        .WithMany("Guesses")
                         .HasForeignKey("SessionStageId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -197,6 +203,11 @@ namespace StickedWords.DbMigrations.Migrations.Sqlite
                     b.Navigation("FlashCards");
 
                     b.Navigation("Stages");
+                });
+
+            modelBuilder.Entity("StickedWords.Domain.Models.SessionStage", b =>
+                {
+                    b.Navigation("Guesses");
                 });
 #pragma warning restore 612, 618
         }

--- a/src/StickedWords.Domain/DateTimeExtensions.cs
+++ b/src/StickedWords.Domain/DateTimeExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace StickedWords.Domain;
+
+public static class DateTimeExtensions
+{
+    public static long ToUnixTime(this DateTimeOffset date) =>
+        date.ToUnixTimeMilliseconds();
+}

--- a/src/StickedWords.Domain/Exceptions/GuessNotFoundException.cs
+++ b/src/StickedWords.Domain/Exceptions/GuessNotFoundException.cs
@@ -1,0 +1,14 @@
+﻿namespace StickedWords.Domain.Exceptions;
+
+public sealed class GuessNotFoundException : Exception
+{
+    private static readonly string _message = "Guess not found for flash card";
+
+    public GuessNotFoundException(long flashCardId) : base(_message)
+    {
+        FlashCardId = flashCardId;
+    }
+
+
+    public long FlashCardId { get; }
+}

--- a/src/StickedWords.Domain/Exceptions/LearningSessionNotActiveException.cs
+++ b/src/StickedWords.Domain/Exceptions/LearningSessionNotActiveException.cs
@@ -1,0 +1,8 @@
+﻿namespace StickedWords.Domain.Exceptions;
+
+public sealed class LearningSessionNotActiveException : Exception
+{
+    private static readonly string _message = "Learning session is not active";
+
+    public LearningSessionNotActiveException() : base(_message) { }
+}

--- a/src/StickedWords.Domain/Exceptions/LearningSessionNotFoundException.cs
+++ b/src/StickedWords.Domain/Exceptions/LearningSessionNotFoundException.cs
@@ -1,0 +1,13 @@
+﻿namespace StickedWords.Domain.Exceptions;
+
+public sealed class LearningSessionNotFoundException : Exception
+{
+    private static readonly string _message = "Learning session is not found";
+
+    public LearningSessionNotFoundException(long sessionId) : base(_message)
+    {
+        LearningSessionId = sessionId;
+    }
+
+    public long LearningSessionId { get; }
+}

--- a/src/StickedWords.Domain/LearningSessionOptions.cs
+++ b/src/StickedWords.Domain/LearningSessionOptions.cs
@@ -9,4 +9,6 @@ public record LearningSessionOptions : IConfigurationOptions
     public TimeSpan ExpireAfter { get; init; } = TimeSpan.FromHours(3);
 
     public int FlashCardCount { get; init; } = 10;
+
+    public TimeSpan RepeatFlashCardPeriod { get; init; } = TimeSpan.FromDays(7);
 }

--- a/src/StickedWords.Domain/Models/FlashCard.cs
+++ b/src/StickedWords.Domain/Models/FlashCard.cs
@@ -20,7 +20,19 @@ public class FlashCard
 
     public int Rate { get; private set; }
 
+    public DateTimeOffset RepeatAt { get; private set; }
+
+    public long RepeatAtUnixTime { get; private set; }
+
     public DateTimeOffset CreatedAt { get; private set; }
+
+    public void UpdateRate(int rate, LearningSessionOptions options)
+    {
+        Rate = rate;
+        // TODO: Take result history. It should affect to rate and next RepeatAt
+        RepeatAt = DateTimeOffset.UtcNow.Add(options.RepeatFlashCardPeriod);
+        RepeatAtUnixTime = RepeatAt.ToUnixTime();
+    }
 
     public static FlashCard Create(string word, string translation)
     {
@@ -32,6 +44,7 @@ public class FlashCard
             Word = word,
             Translation = translation,
             CreatedAt = DateTimeOffset.UtcNow,
+            RepeatAt = DateTimeOffset.UtcNow,
             Rate = 1000
         };
     }

--- a/src/StickedWords.Domain/Models/LearningSessionResults.cs
+++ b/src/StickedWords.Domain/Models/LearningSessionResults.cs
@@ -1,0 +1,8 @@
+﻿namespace StickedWords.Domain.Models;
+
+public record LearningSessionResults
+{
+    public LearningSessionState State { get; init; }
+
+    public int FlashCardCount { get; init; }
+}

--- a/src/StickedWords.Domain/Models/SessionStage.cs
+++ b/src/StickedWords.Domain/Models/SessionStage.cs
@@ -43,6 +43,7 @@ public record SessionStage
     public void Unactivate()
     {
         IsActive = false;
+        CurrentFlashCard = null;
     }
 
     public void Activate(IReadOnlyList<SessionFlashCard> flashCards)

--- a/src/StickedWords.Domain/Repositories/ILearningSessionRepository.cs
+++ b/src/StickedWords.Domain/Repositories/ILearningSessionRepository.cs
@@ -4,6 +4,8 @@ namespace StickedWords.Domain.Repositories;
 
 public interface ILearningSessionRepository
 {
+    Task<LearningSession?> GetById(long sessionId, CancellationToken cancellationToken);
+
     Task<LearningSession?> GetActive(CancellationToken cancellationToken);
 
     void Add(LearningSession learningSession);

--- a/src/StickedWords.Infrastructure/Repositories/LearningSessionRepository.cs
+++ b/src/StickedWords.Infrastructure/Repositories/LearningSessionRepository.cs
@@ -13,6 +13,16 @@ internal class LearningSessionRepository : ILearningSessionRepository
         _context = dbContext;
     }
 
+    public async Task<LearningSession?> GetById(long sessionId, CancellationToken cancellationToken)
+    {
+        return await _context.LearningSessions
+            .Include(x => x.Stages)
+            .ThenInclude(x => x.Guesses)
+            .Include(x => x.FlashCards)
+            .ThenInclude(x => x.FlashCard)
+            .FirstOrDefaultAsync(x => x.Id == sessionId, cancellationToken);
+    }
+
     public async Task<LearningSession?> GetActive(CancellationToken cancellationToken)
     {
         return await _context.LearningSessions

--- a/src/StickedWords.UI/src/models/LearningSession.ts
+++ b/src/StickedWords.UI/src/models/LearningSession.ts
@@ -1,4 +1,6 @@
 export class LearningSession {
+  id!: number;
+  state!: LearningSessionState;
   exerciseType!: ExerciseType;
   flashCardId?: number;
   flashCardCount!: number;
@@ -6,6 +8,8 @@ export class LearningSession {
   static fromJson(json: any): LearningSession {
     const result = new LearningSession();
 
+    result.id = json.id;
+    result.state = mapSessionState(json.state);
     result.exerciseType = LearningSession.mapExerciseType(json.exerciseType);
     result.flashCardId = json.flashCardId ?? null;
     result.flashCardCount = json.flashCardCount ?? 0;
@@ -24,8 +28,25 @@ export class LearningSession {
   }
 }
 
+export const mapSessionState = (src: string): LearningSessionState => {
+  if (!src) {
+    return LearningSessionState.None;
+  }
+
+  return Object.values(LearningSessionState).includes(src as LearningSessionState)
+    ? src as LearningSessionState
+    : LearningSessionState.None;
+}
+
 export enum ExerciseType {
   None = "None",
   TranslateForeignToNative = "TranslateForeignToNative",
   TranslateNativeToForeign = "TranslateNativeToForeign"
+}
+
+export enum LearningSessionState {
+  None = "None",
+  Active = "Active",
+  Finished = "Finished",
+  Expired = "Expired"
 }

--- a/src/StickedWords.UI/src/models/LearningSessionResults.ts
+++ b/src/StickedWords.UI/src/models/LearningSessionResults.ts
@@ -1,0 +1,15 @@
+import { LearningSessionState, mapSessionState } from "./LearningSession";
+
+export class LearningSessionResults {
+  state!: LearningSessionState;
+  flashCardCount!: number;
+
+  static fromJson(json: any): LearningSessionResults {
+    const result = new LearningSessionResults();
+
+    result.state = mapSessionState(json.state);
+    result.flashCardCount = json.flashCardCount ?? 0;
+
+    return result;
+  }
+}

--- a/src/StickedWords.UI/src/router/index.ts
+++ b/src/StickedWords.UI/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import FlashCardListView from '@/views/FlashCardListView.vue'
 import AddFlashCardView from '@/views/AddFlashCardView.vue'
 import LearningSessionView from '@/views/LearningSessionView.vue'
+import LearningSessionResultsView from '@/views/LearningSessionResultsView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -20,6 +21,11 @@ const router = createRouter({
       path: '/session',
       name: 'learning-session',
       component: LearningSessionView
+    },
+    {
+      path: '/session-results',
+      name: 'learning-session-results',
+      component: LearningSessionResultsView
     }
 
     // TODO: создать компонент сессии

--- a/src/StickedWords.UI/src/services/LearningSessionService.ts
+++ b/src/StickedWords.UI/src/services/LearningSessionService.ts
@@ -1,9 +1,28 @@
 import { environments } from "@/environments";
 import { LearningSession } from "@/models/LearningSession";
+import { LocalDataStorage } from "./LocalDataStorage";
+import { LearningSessionResults } from "@/models/LearningSessionResults";
 
 export class LearningSessionService {
 
   private readonly _baseUrl = `${environments.API_BASE_URL}/learning-sessions`;
+  private readonly _dataStorage = new LocalDataStorage();
+  private readonly _sessionIdStorageKey = 'LEARNING_SESSION_ID';
+
+  async getById(id: number): Promise<LearningSession | undefined> {
+    const url = `${this._baseUrl}/${id}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Response status: ${response.status}`);
+    }
+
+    const json = await response.json();
+    if (!json) {
+      return undefined;
+    }
+
+    return LearningSession.fromJson(json);
+  }
 
   async getActive(): Promise<LearningSession | undefined> {
     const response = await fetch(this._baseUrl);
@@ -17,6 +36,18 @@ export class LearningSessionService {
     }
 
     return LearningSession.fromJson(json);
+  }
+
+  async getResults(id: number): Promise<LearningSessionResults> {
+    const url = `${this._baseUrl}/${id}/results`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Response status: ${response.status}`);
+    }
+
+    const json = await response.json();
+
+    return LearningSessionResults.fromJson(json);
   }
 
   async start(): Promise<LearningSession> {
@@ -33,5 +64,17 @@ export class LearningSessionService {
     const json = await response.json();
 
     return LearningSession.fromJson(json);
+  }
+
+  getCurrentSessionId(): number | undefined {
+    return this._dataStorage.get<number>(this._sessionIdStorageKey);
+  }
+
+  saveCurrentSessionId(sessionId: number) {
+    this._dataStorage.save(this._sessionIdStorageKey, sessionId);
+  }
+
+  deleteCurrentSessionId() {
+    this._dataStorage.delete(this._sessionIdStorageKey);
   }
 }

--- a/src/StickedWords.UI/src/services/LocalDataStorage.ts
+++ b/src/StickedWords.UI/src/services/LocalDataStorage.ts
@@ -1,0 +1,20 @@
+export class LocalDataStorage {
+
+  get<TData>(key: string): TData | undefined {
+    const json = localStorage.getItem(key);
+    if (!json) {
+      return undefined;
+    }
+
+    return JSON.parse(json) as TData;
+  }
+
+  save<TData>(key: string, data: TData) {
+    const json = JSON.stringify(data);
+    localStorage.setItem(key, json);
+  }
+
+  delete(key: string) {
+    localStorage.removeItem(key);
+  }
+}

--- a/src/StickedWords.UI/src/views/LearningSessionResultsView.vue
+++ b/src/StickedWords.UI/src/views/LearningSessionResultsView.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { LearningSessionState } from '@/models/LearningSession';
+import { ErrorHandler } from '@/services/ErrorHandler';
+import { LearningSessionService } from '@/services/LearningSessionService';
+import { onMounted, ref } from 'vue';
+import { useRouter } from 'vue-router';
+
+const props = defineProps({
+  sessionId: { type: Number, required: true }
+});
+
+const router = useRouter();
+const service = new LearningSessionService();
+const sessionState = ref<LearningSessionState>(LearningSessionState.None);
+const cardCount = ref<number>(0);
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+const initView = async () => {
+  await loadData();
+}
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+
+    const results = await service.getResults(props.sessionId);
+    sessionState.value = results.state;
+    cardCount.value = results.flashCardCount;
+  } catch (err) {
+    sessionState.value = LearningSessionState.None;
+    cardCount.value = 0;
+    error.value = ErrorHandler.getMessage(err);
+  } finally {
+    loading.value = false;
+  }
+}
+
+const onCompleteClicked = () => {
+  service.deleteCurrentSessionId();
+  router.push('/');
+}
+
+onMounted(initView);
+
+</script>
+
+<template>
+  <main class="learning-session-results-view">
+    <div
+      v-if="sessionState === LearningSessionState.Expired"
+      class="learning-session-results-view__title"
+    >
+      Session expired
+    </div>
+    <div
+      v-if="sessionState === LearningSessionState.Finished"
+      class="learning-session-results-view__title"
+    >
+      Session finished
+    </div>
+    <div class="learning-session-results-view__description">
+      Learned words: {{ cardCount }}
+    </div>
+    <div class="learning-session-results-view__buttons">
+      <button class="learning-session-results-view__add-button primary"
+        @click="onCompleteClicked()"
+        :class="[loading ? 'disabled' : '']"
+      >Complete</button>
+    </div>
+  </main>
+</template>
+
+<style scoped lang="scss">
+
+.learning-session-results-view {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  flex: 1;
+
+  &__title {
+    font-weight: 600;
+  }
+
+  &__description {
+    margin-top: 10px;
+    margin-bottom: 30px;
+  }
+
+  &__buttons {
+    margin-top: 20px;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+}
+</style>

--- a/tests/StickedWords.UnitTests/LearningSessionTests.cs
+++ b/tests/StickedWords.UnitTests/LearningSessionTests.cs
@@ -1,0 +1,122 @@
+﻿using StickedWords.Domain;
+using StickedWords.Domain.Models;
+
+namespace StickedWords.UnitTests;
+
+public class LearningSessionTests
+{
+    [Test]
+    public void Finish_StartedSession_StateFinished()
+    {
+        // Arrange
+        var session = GetStartedSession([GetFlashCard()]);
+        var options = GetOptions();
+
+        // Act
+        session.Finish(options);
+
+        // Assert
+        Assert.That(session.State, Is.EqualTo(LearningSessionState.Finished));
+    }
+
+    [Test]
+    public void Finish_StartedSession_StagesUnactive()
+    {
+        // Arrange
+        var session = GetStartedSession([GetFlashCard()]);
+        var options = GetOptions();
+
+        // Act
+        session.Finish(options);
+
+        // Assert
+        foreach (var stage in session.Stages)
+        {
+            Assert.That(stage.IsActive, Is.False);
+        }
+    }
+
+    [Test]
+    public void Finish_AllGuessesCorrect_RateIs100()
+    {
+        // Arrange
+        var flashCard = GetFlashCard();
+        var session = GetStartedSession([flashCard]);
+        var options = GetOptions();
+        session.TryMoveToNextFlashCard(GuessResult.Correct);
+        session.TryMoveToNextFlashCard(GuessResult.Correct);
+
+        // Act
+        session.Finish(options);
+
+        // Assert
+        Assert.That(flashCard.Rate, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void Finish_HalfGuessesCorrect_RateIs50()
+    {
+        // Arrange
+        var flashCard = GetFlashCard();
+        var session = GetStartedSession([flashCard]);
+        var options = GetOptions();
+        session.TryMoveToNextFlashCard(GuessResult.Correct);
+        session.TryMoveToNextFlashCard(GuessResult.Wrong);
+
+        // Act
+        session.Finish(options);
+
+        // Assert
+        Assert.That(flashCard.Rate, Is.EqualTo(50));
+    }
+
+    [Test]
+    public void Finish_AllGuessesWrong_RateIs0()
+    {
+        // Arrange
+        var flashCard = GetFlashCard();
+        var session = GetStartedSession([flashCard]);
+        var options = GetOptions();
+        session.TryMoveToNextFlashCard(GuessResult.Wrong);
+        session.TryMoveToNextFlashCard(GuessResult.Wrong);
+
+        // Act
+        session.Finish(options);
+
+        // Assert
+        Assert.That(flashCard.Rate, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Finish_NoGuesses_RateIs0()
+    {
+        // Arrange
+        var flashCard = GetFlashCard();
+        var session = GetStartedSession([flashCard]);
+        var options = GetOptions();
+
+        // Act
+        session.Finish(options);
+
+        // Assert
+        Assert.That(flashCard.Rate, Is.EqualTo(0));
+    }
+
+    private static LearningSession GetStartedSession(FlashCard[] flashCards)
+    {
+        var session = LearningSession.Create(flashCards);
+        session.Start(TimeSpan.FromMinutes(1));
+
+        return session;
+    }
+
+    private static FlashCard GetFlashCard() => FlashCard.Create("word1", "слово1");
+
+    private static LearningSessionOptions GetOptions()
+    {
+        return new()
+        {
+            RepeatFlashCardPeriod = TimeSpan.FromMinutes(5)
+        };
+    }
+}


### PR DESCRIPTION
- На клиенте хранится идентификатор активной сессии. Если на клиенте информации нет, получаем активную сессию с сервера. Статус сессии дальше определяется через запрос к api по идентификатору сессии.
- Добавил рассчет рейтинга слова и даты следующего заучивания слова. Для поддержки сортировки и фильтрации в SQLite дату следующего заучивания сохраняем в виде числа.
- В editorconfig добавил правило чтобы название приватных полей начиналось с подчеркивания и маленькой буквы.

---
closes #12 