### PR TITLE
feat: Add session progress

### DIFF
--- a/src/StickedWords.API/Mappers/LearningSessionMapper.cs
+++ b/src/StickedWords.API/Mappers/LearningSessionMapper.cs
@@ -16,7 +16,16 @@ internal static class LearningSessionMapper
             State = source.State,
             ExerciseType = activeStage?.ExerciseType ?? ExerciseType.None,
             FlashCardId = activeStage?.CurrentFlashCard?.FlashCardId,
-            FlashCardCount = source.FlashCards.Count
+            FlashCardCount = source.FlashCards.Count,
+            Stages = source.Stages
+                .OrderBy(x => x.OrdNumber)
+                .Select(x => new LearningSessionStageDto
+                {
+                    Id = x.Id,
+                    OrdNumber = x.OrdNumber,
+                    CompletedFlashCardCount = x.Guesses.Count
+                })
+                .ToArray()
         };
     }
 

--- a/src/StickedWords.API/Models/LearningSessionDto.cs
+++ b/src/StickedWords.API/Models/LearningSessionDto.cs
@@ -13,4 +13,6 @@ public record LearningSessionDto
     public long? FlashCardId { get; init; }
 
     public int FlashCardCount { get; init; }
+
+    public IReadOnlyCollection<LearningSessionStageDto> Stages { get; init; } = [];
 }

--- a/src/StickedWords.API/Models/LearningSessionStageDto.cs
+++ b/src/StickedWords.API/Models/LearningSessionStageDto.cs
@@ -1,0 +1,10 @@
+﻿namespace StickedWords.API.Models;
+
+public record LearningSessionStageDto
+{
+    public long Id { get; init; }
+
+    public int OrdNumber { get; init; }
+
+    public int CompletedFlashCardCount { get; init; }
+}

--- a/src/StickedWords.UI/src/models/LearningSession.ts
+++ b/src/StickedWords.UI/src/models/LearningSession.ts
@@ -1,9 +1,12 @@
+import { LearningSessionStage } from "./LearningSessionStage";
+
 export class LearningSession {
   id!: number;
   state!: LearningSessionState;
   exerciseType!: ExerciseType;
   flashCardId?: number;
   flashCardCount!: number;
+  stages!: LearningSessionStage[];
 
   static fromJson(json: any): LearningSession {
     const result = new LearningSession();
@@ -13,6 +16,7 @@ export class LearningSession {
     result.exerciseType = LearningSession.mapExerciseType(json.exerciseType);
     result.flashCardId = json.flashCardId ?? null;
     result.flashCardCount = json.flashCardCount ?? 0;
+    result.stages = (json.stages ?? []).map((x: any) => LearningSessionStage.fromJson(x))
 
     return result;
   }

--- a/src/StickedWords.UI/src/models/LearningSessionStage.ts
+++ b/src/StickedWords.UI/src/models/LearningSessionStage.ts
@@ -1,0 +1,15 @@
+export class LearningSessionStage {
+  id!: number;
+  ordNumber!: number;
+  completedFlashCardCount!: number;
+
+  static fromJson(json: any): LearningSessionStage {
+    const result = new LearningSessionStage();
+
+    result.id = json.id;
+    result.ordNumber = json.ordNumber ?? 0;
+    result.completedFlashCardCount = json.completedFlashCardCount ?? 0;
+
+    return result;
+  }
+}

--- a/src/StickedWords.UI/src/views/LearningSessionProgress.vue
+++ b/src/StickedWords.UI/src/views/LearningSessionProgress.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { LearningSession } from '@/models/LearningSession';
+import type { LearningSessionStage } from '@/models/LearningSessionStage';
+
+const props = defineProps({
+  session: { type: LearningSession, required: true }
+});
+
+const getStageCompletePercentage = (stage: LearningSessionStage) => {
+  const percentage = (stage.completedFlashCardCount / props.session.flashCardCount) * 100;
+
+  return Math.ceil(percentage) + '%'
+}
+
+</script>
+
+<template>
+  <div class="learning-session-progress">
+    <div v-for="stage of session.stages" :key="stage.id" class="learning-session-progress__stage">
+      <div
+        class="learning-session-progress__stage_completed"
+        :style="{ width: getStageCompletePercentage(stage) }"
+      ></div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+
+.learning-session-progress {
+  display: flex;
+  flex-direction: row;
+  margin: 10px 0px;
+
+  &__stage {
+    flex: 1;
+    margin: 2px;
+    height: 5px;
+    border: 1px solid var(--vt-c-text-green);
+    border-radius: 3px;
+
+    &_completed {
+      height: 100%;
+      background-color: var(--vt-c-text-green);
+    }
+  }
+}
+</style>

--- a/src/StickedWords.UI/src/views/LearningSessionView.vue
+++ b/src/StickedWords.UI/src/views/LearningSessionView.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
-import { ExerciseType, LearningSessionState } from '@/models/LearningSession';
+import { ExerciseType, LearningSession, LearningSessionState } from '@/models/LearningSession';
 import { ErrorHandler } from '@/services/ErrorHandler';
 import { LearningSessionService } from '@/services/LearningSessionService';
 import { computed, onMounted, ref } from 'vue';
 import TranslateForeignToNativeExerciseView from './exercises/TranslateForeignToNativeExerciseView.vue';
 import TranslateNativeToForeignExerciseView from './exercises/TranslateNativeToForeignExerciseView.vue';
 import LearningSessionResultsView from './LearningSessionResultsView.vue';
+import LearningSessionProgress from './LearningSessionProgress.vue';
 
 const service = new LearningSessionService();
+const session = ref<LearningSession | null>(null);
 const cardCount = ref<number>(0);
 const sessionState = ref<LearningSessionState>(LearningSessionState.None);
 const exerciseType = ref<ExerciseType>(ExerciseType.None);
@@ -41,12 +43,12 @@ const loadData = async () => {
   try {
     loading.value = true;
 
-    const session = await loadLearningSession();
-    sessionId.value = session.id;
-    sessionState.value = session.state;
-    flashCardId.value = session.flashCardId;
-    exerciseType.value = session.exerciseType;
-    cardCount.value = session.flashCardCount;
+    session.value = await loadLearningSession();
+    sessionId.value = session.value.id;
+    sessionState.value = session.value.state;
+    flashCardId.value = session.value.flashCardId;
+    exerciseType.value = session.value.exerciseType;
+    cardCount.value = session.value.flashCardCount;
   } catch (err) {
     sessionId.value = -1;
     sessionState.value = LearningSessionState.None;
@@ -71,6 +73,9 @@ onMounted(initView);
       ></LearningSessionResultsView>
     </div>
     <div v-else-if="flashCardId">
+      <LearningSessionProgress v-if="session"
+        :session="session"
+      ></LearningSessionProgress>
       <div v-if="exerciseType === ExerciseType.TranslateForeignToNative">
         <TranslateForeignToNativeExerciseView
           :flashCardId="flashCardId"


### PR DESCRIPTION
Добавил визуализацию прогресса прохождения сессии. Для этого в ApiModel сессии добавил список этапов с информацией о количестве пройденных карточек. На странице проведения сессии заучивания добавил компонент для визуализации прогресса. Для каждого этапа отображается рамочка, которая заполняется по мере получения ответов.

closes #11 