### PR TITLE
feat: Added ability to choose db provider from configuration

### DIFF
--- a/ci-cd/k8s/config.yaml
+++ b/ci-cd/k8s/config.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sticked-words-config
 data:
   ApplyMigrations: "false"
+  DbProvider: "PostgreSQL"
 ---
 apiVersion: v1
 kind: Secret

--- a/src/StickedWords.API/appsettings.OrangePi.json
+++ b/src/StickedWords.API/appsettings.OrangePi.json
@@ -21,9 +21,9 @@
       }
     ]
   },
+  "URLS": "http://*:8080",
   "ConnectionStrings": {
     "StickedWordsDbContext": "Data Source=/home/sticked-words/db/stickedwords.db"
   },
-  "ApplyMigrations": true,
-  "URLS": "http://*:8080"
+  "ApplyMigrations": true
 }

--- a/src/StickedWords.API/appsettings.json
+++ b/src/StickedWords.API/appsettings.json
@@ -1,7 +1,4 @@
 {
-  "ConnectionStrings": {
-    "StickedWordsDbContext": "Data Source=|DataDirectory|stickedwords.db"
-  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
     "MinimumLevel": {
@@ -18,5 +15,9 @@
     ],
     "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "StickedWordsDbContext": "Data Source=|DataDirectory|stickedwords.db"
+  },
+  "DbProvider": "SQLite"
 }

--- a/src/StickedWords.Domain/Exceptions/DbProviderNotSupportedException.cs
+++ b/src/StickedWords.Domain/Exceptions/DbProviderNotSupportedException.cs
@@ -1,0 +1,14 @@
+﻿namespace StickedWords.Domain.Exceptions;
+
+public sealed class DbProviderNotSupportedException : Exception
+{
+    private static readonly string _message = "Db provider [{0}] is not supported";
+
+    public DbProviderNotSupportedException(string dbProvider)
+        : base(string.Format(_message, dbProvider))
+    {
+        DbProvider = dbProvider;
+    }
+
+    public string DbProvider { get; }
+}

--- a/src/StickedWords.Infrastructure.Postgres/Consts.cs
+++ b/src/StickedWords.Infrastructure.Postgres/Consts.cs
@@ -1,0 +1,6 @@
+﻿namespace StickedWords.Infrastructure.Postgres;
+
+public static class Consts
+{
+    public const string DbProviderName = "POSTGRESQL";
+}

--- a/src/StickedWords.Infrastructure.Sqlite/Consts.cs
+++ b/src/StickedWords.Infrastructure.Sqlite/Consts.cs
@@ -1,0 +1,6 @@
+﻿namespace StickedWords.Infrastructure.Sqlite;
+
+public static class Consts
+{
+    public const string DbProviderName = "SQLITE";
+}


### PR DESCRIPTION
Добавил возможность выбрать тип базы данных из конфигурации, при помощи опции DbProvider.
Поддерживается 2 значения:
- SQLite
- PostgreSQL

Позволяет использовать один и тот же код и на OrangePi и в облаке и на локале.

---
closes #57 