### PR TITLE
fix: add digest to output

### DIFF
--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -49,7 +49,13 @@ jobs:
           labels: ${{ steps.meta-app.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          
+
+      - name: Output app image metadata
+        run: |
+          echo "Labels: ${{ steps.meta-app.outputs.labels }}"
+          echo "Tags: ${{ steps.meta-app.outputs.tags }}"
+          echo "Digest: ${{ steps.docker-build-app.outputs.digest }}"
+
       - name: Extract migrations metadata (tags, labels) for Docker
         id: meta-migrations
         uses: docker/metadata-action@v5
@@ -71,12 +77,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Output app image metadata
-        run: |
-          echo "Labels: ${{ steps.meta-app.outputs.labels }}"
-          echo "Tags: ${{ steps.meta-app.outputs.tags }}"
-          echo "Digest: ${{ steps.docker-build-app.outputs.digest }}"
-          
       - name: Output migrations image metadata
         run: |
           echo "Labels: ${{ steps.meta-migrations.outputs.labels }}"


### PR DESCRIPTION
- Добавил вывод digest docker-образа при сборке
- Убрал триггер workflow по добавлению тэга
- Поменял порядок шагов, чтобы вывод metadata был ближе к образу (app/migrations)

---
closes #4 