### PR TITLE
feat: Go to next screen on enter

### DIFF
--- a/ci-cd/docker-compose.yaml
+++ b/ci-cd/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   app:
-    image: "molokmax/sticked-words:v0.1.1"
+    image: "molokmax/sticked-words:v0.1.2"
     ports:
       - "8080:8080"
     environment:

--- a/ci-cd/k8s/deploy.yaml
+++ b/ci-cd/k8s/deploy.yaml
@@ -15,7 +15,7 @@ spec:
         app: sticked-words
     spec:
       containers:
-      - image: molokmax/sticked-words:0.1.1
+      - image: molokmax/sticked-words:0.1.2
         name: sticked-words
         env:
           - name: ApplyMigrations

--- a/src/StickedWords.UI.React/package.json
+++ b/src/StickedWords.UI.React/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sticked-words",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/src/StickedWords.UI.React/src/components/AddFlashCard/AddFlashCard.tsx
+++ b/src/StickedWords.UI.React/src/components/AddFlashCard/AddFlashCard.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router';
 import { ErrorHandler } from '../../services/ErrorHandler';
 import { FlashCardService } from '../../services/FlashCardService';
-import { useNavigate } from 'react-router';
-
 import { CreateFlashCardRequest } from '../../models/CreateFlashCardRequest';
+import { useEnterKey } from '../../services/hooks';
 
 import './AddFlashCard.scss'
 
@@ -44,6 +44,8 @@ function AddFlashCard() {
             .catch(err => setError(ErrorHandler.getMessage(err)))
             .finally(() => setLoading(false));
     }
+
+    useEnterKey(onAddClicked);
 
     return (
         <main className="add-flash-card">

--- a/src/StickedWords.UI.React/src/components/Exercises/TranslateForeignToNativeExercise/TranslateForeignToNativeExercise.tsx
+++ b/src/StickedWords.UI.React/src/components/Exercises/TranslateForeignToNativeExercise/TranslateForeignToNativeExercise.tsx
@@ -3,6 +3,7 @@ import { ErrorHandler } from '../../../services/ErrorHandler';
 import { GuessResult, TranslateGuessResult } from '../../../models/exercises/TranslateGuessResult';
 import { TranslateForeignToNativeExerciseService } from '../../../services/exercises/TranslateForeignToNativeExerciseService';
 import { TranslateGuess } from '../../../models/exercises/TranslateGuess';
+import { useEnterKey } from '../../../services/hooks';
 
 import './TranslateForeignToNativeExercise.scss';
 
@@ -73,6 +74,8 @@ function TranslateForeignToNativeExercise({ flashCardId, onNext }: Props) {
             })
             .finally(() => setLoading(false));
     }
+
+    useEnterKey(isGuessChecked ? onNext : onCheckClicked);
 
     useEffect(() => loadData(flashCardId), [flashCardId]);
 

--- a/src/StickedWords.UI.React/src/components/Exercises/TranslateNativeToForeignExercise/TranslateNativeToForeignExercise.tsx
+++ b/src/StickedWords.UI.React/src/components/Exercises/TranslateNativeToForeignExercise/TranslateNativeToForeignExercise.tsx
@@ -3,6 +3,7 @@ import { ErrorHandler } from '../../../services/ErrorHandler';
 import { GuessResult, TranslateGuessResult } from '../../../models/exercises/TranslateGuessResult';
 import { TranslateNativeToForeignExerciseService } from '../../../services/exercises/TranslateNativeToForeignExerciseService';
 import { TranslateGuess } from '../../../models/exercises/TranslateGuess';
+import { useEnterKey } from '../../../services/hooks';
 
 import './TranslateNativeToForeignExercise.scss';
 
@@ -73,6 +74,8 @@ function TranslateNativeToForeignExercise({ flashCardId, onNext }: Props) {
             })
             .finally(() => setLoading(false));
     }
+
+    useEnterKey(isGuessChecked ? onNext : onCheckClicked);
 
     useEffect(() => loadData(flashCardId), [flashCardId]);
 

--- a/src/StickedWords.UI.React/src/components/LearningSessionResults/LearningSessionResults.tsx
+++ b/src/StickedWords.UI.React/src/components/LearningSessionResults/LearningSessionResults.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 import { ErrorHandler } from '../../services/ErrorHandler';
 import { LearningSessionState } from '../../models/LearningSession';
 import { LearningSessionService } from '../../services/LearningSessionService';
+import { useEnterKey } from '../../services/hooks';
 
 import './LearningSessionResults.scss'
 
@@ -42,9 +43,10 @@ function LearningSessionResults({ sessionId }: Props) {
         navigate("/");
     }
 
+    useEnterKey(onCompleteClicked);
+
     useEffect(() => {
         loadData(sessionId);
-        console.log('use effect');
     }, [sessionId]);
 
     if (sessionState === LearningSessionState.Expired) {

--- a/src/StickedWords.UI.React/src/services/hooks.ts
+++ b/src/StickedWords.UI.React/src/services/hooks.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+export const useEnterKey = (callback: () => void) => {
+    useEffect(() => {
+        function handleKeyDown(ev: KeyboardEvent) {
+            if (ev.key === 'Enter') {
+                callback();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [callback]);
+}


### PR DESCRIPTION
Добавил хук который создает глобальный обработчик события нажатия на клавишу. 
Вешать только на input - не вариант, так как хочется переходить на следующий экран по Enter после того, как увидел результат проверки слова или результаты всей сессии.

---
closes #49