### PR TITLE
feat: block buttons on loading

### DIFF
--- a/ci-cd/docker-compose.yaml
+++ b/ci-cd/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   app:
-    image: "molokmax/sticked-words:v0.1.4"
+    image: "molokmax/sticked-words:v0.1.5"
     ports:
       - "8080:8080"
     environment:

--- a/ci-cd/k8s/deploy.yaml
+++ b/ci-cd/k8s/deploy.yaml
@@ -15,7 +15,7 @@ spec:
         app: sticked-words
     spec:
       containers:
-      - image: molokmax/sticked-words:0.1.4
+      - image: molokmax/sticked-words:0.1.5
         name: sticked-words
         env:
           - name: ApplyMigrations

--- a/src/StickedWords.UI.React/package.json
+++ b/src/StickedWords.UI.React/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sticked-words",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/src/StickedWords.UI.React/src/components/Exercises/TranslateForeignToNativeExercise/TranslateForeignToNativeExercise.scss
+++ b/src/StickedWords.UI.React/src/components/Exercises/TranslateForeignToNativeExercise/TranslateForeignToNativeExercise.scss
@@ -52,5 +52,9 @@
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
+    
+    button {
+      min-width: 100px;
+    }
   }
 }

--- a/src/StickedWords.UI.React/src/components/Exercises/TranslateForeignToNativeExercise/TranslateForeignToNativeExercise.tsx
+++ b/src/StickedWords.UI.React/src/components/Exercises/TranslateForeignToNativeExercise/TranslateForeignToNativeExercise.tsx
@@ -53,7 +53,7 @@ function TranslateForeignToNativeExercise({ flashCardId, onNext }: Props) {
     }
 
     const onCheckClicked = () => {
-        if (!isFormValid()) {
+        if (loading || !isFormValid()) {
             return;
         }
 
@@ -102,18 +102,19 @@ function TranslateForeignToNativeExercise({ flashCardId, onNext }: Props) {
         ? (
             <button
                 className="translate-foreign-to-native-exercise__check-button primary"
+                disabled={ loading }
                 onClick={ onNext }
             >
-                Next
+                { loading ? 'Loading...' : 'Next' }
             </button>
         )
         : (
             <button
                 className="translate-foreign-to-native-exercise__check-button primary"
-                disabled={ !isFormValid() }
+                disabled={ loading || !isFormValid() }
                 onClick={ onCheckClicked }
             >
-                Check
+                { loading ? 'Loading...' : 'Check' }
             </button>
         );
 

--- a/src/StickedWords.UI.React/src/components/Exercises/TranslateNativeToForeignExercise/TranslateNativeToForeignExercise.scss
+++ b/src/StickedWords.UI.React/src/components/Exercises/TranslateNativeToForeignExercise/TranslateNativeToForeignExercise.scss
@@ -52,5 +52,9 @@
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
+
+    button {
+      min-width: 100px;
+    }
   }
 }

--- a/src/StickedWords.UI.React/src/components/Exercises/TranslateNativeToForeignExercise/TranslateNativeToForeignExercise.tsx
+++ b/src/StickedWords.UI.React/src/components/Exercises/TranslateNativeToForeignExercise/TranslateNativeToForeignExercise.tsx
@@ -102,18 +102,19 @@ function TranslateNativeToForeignExercise({ flashCardId, onNext }: Props) {
         ? (
             <button
                 className="translate-native-to-foreign-exercise__check-button primary"
+                disabled={ loading }
                 onClick={ onNext }
             >
-                Next
+                { loading ? 'Loading...' : 'Next' }
             </button>
         )
         : (
             <button
                 className="translate-native-to-foreign-exercise__check-button primary"
-                disabled={ !isFormValid() }
+                disabled={ loading || !isFormValid() }
                 onClick={ onCheckClicked }
             >
-                Check
+                { loading ? 'Loading...' : 'Check' }
             </button>
         );
 


### PR DESCRIPTION
В момент загрузки данных с сервера, кнопки Check и Next в упражнениях блокируются и надпись меняется на Loading

---
closes #48